### PR TITLE
Add AWS IoT MQTT to resolve 429 Rate Limit issues and provde real-time device shadow updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Secrets
+.env
+.dev-token
+
 # Ignore everything except integration code
 custom_components/exo_pool/.storage/
 custom_components/exo_pool/*.db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: test dev dev-stop dev-logs dev-restart
+
+# --- Tests ---
+
+test:
+	python3 -m pytest tests/ -q
+
+test-v:
+	python3 -m pytest tests/ -v
+
+# --- Dev environment ---
+
+dev:
+	docker compose -f docker-compose.dev.yml up -d
+	python3 scripts/dev-setup.py
+
+stop:
+	docker compose -f docker-compose.dev.yml down
+
+logs:
+	docker logs ha-exo-pool-dev -f --tail 50
+
+restart:
+	docker restart ha-exo-pool-dev

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ A custom integration to connect your Zodiac iAqualink **Exo** pool system to Hom
 
 ## 🆕 What’s New
 
+- **15 Apr 2026**
+1) **Real-time updates via AWS IoT MQTT.** The integration now connects to the same AWS IoT shadow endpoint used by the official iAqualink app, giving sub-second state sync instead of REST polling. No additional setup required - it uses credentials already provided by the Zodiac login API.
+2) Writes (set points, switches, schedules) now go via MQTT when connected, eliminating 429 rate limit errors on writes.
+3) REST polling is kept as a 1-hour fallback in case MQTT disconnects, but under normal operation all data flows through MQTT push.
+4) AWS credentials are automatically refreshed before expiry (~hourly).
+5) Added `awsiotsdk` as a dependency (installed automatically by HACS).
+
 - **7 Feb 2026**
 1) Small retry fix to get around 401 'token expired' errors on schedule write attempts (and associated logging updates).
 
@@ -62,7 +69,8 @@ A custom integration to connect your Zodiac iAqualink **Exo** pool system to Hom
 - **Climate (experimental)** – Heat Pump control when Aux 2 is configured for heat mode.
 - **Services** – Control and modify schedules (see below).
 - **Diagnostics & Dynamic Device Info** – View hardware configuration and live status; serial number and software version update periodically.
-- **Configurable Refresh Rate** – Adjust the `Refresh Interval` number (300–3600 s, default 600 s) if you see *Too Many Requests* errors.
+- **Real-time MQTT Updates** – Connects to AWS IoT for instant state sync (same protocol as the official app). No MQTT broker or addon required.
+- **Configurable Refresh Rate** – The `Refresh Interval` number (300-3600 s) controls the REST fallback poll interval. Under normal MQTT operation this rarely fires.
 
 ---
 
@@ -141,7 +149,7 @@ After early Node-RED flows and REST template hacks, this dedicated integration w
 ## Limitations
 
 - Restricted to **Exo** devices only; use the core iAqualink integration for other hardware.
-- Commands (set points, Aux switches, etc.) can be slightly laggy; polling is temporarily boosted to ~10 s for ~60 s after changes.
+- Commands (set points, Aux switches, etc.) are near-instant via MQTT. If MQTT is unavailable, writes fall back to REST which may be subject to rate limits.
 - Schedule keys, names and endpoints are determined by the device; disabling a schedule is modelled as `00:00–00:00`.
 - RPM is only relevant to VSP schedules.
 - The heat pump climate entity only appears when Aux 2 is set to heat mode.
@@ -154,6 +162,50 @@ Confirmed working with:
 - **Exo IQ LS** (dual-link ORP & pH, Zodiac VSP pump).
 
 Have success with other models? Please share!
+
+---
+
+## Development
+
+### Prerequisites
+
+- Docker
+- Python 3.9+
+- A Zodiac iAqualink account with an eXO device
+
+### Quick start
+
+```bash
+git clone https://github.com/benjycov/exo_pool.git
+cd exo_pool
+
+# Create .env with your Zodiac credentials
+echo "EXO_EMAIL=your@email.com" > .env
+echo "EXO_PASSWORD=yourpassword" >> .env
+
+# Start a dev HA instance (auto-onboards, configures integration)
+make dev
+
+# Open http://localhost:8125 (login: dev / devdevdev)
+```
+
+### Useful commands
+
+```bash
+make test       # run unit + integration tests
+make logs       # tail the HA container logs
+make restart    # restart HA after code changes (volume-mounted, no rebuild)
+make stop       # stop the container
+```
+
+### Running tests
+
+```bash
+pip install pytest pytest-asyncio awsiotsdk
+python3 -m pytest tests/ -v
+```
+
+Tests are isolated from Home Assistant - no HA installation required to run them.
 
 ---
 

--- a/custom_components/exo_pool/__init__.py
+++ b/custom_components/exo_pool/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.config_entries import (
 from homeassistant.core import HomeAssistant, ServiceCall
 import logging
 from .const import DOMAIN
-from .api import get_coordinator
+from .api import get_coordinator, cleanup_entry
 from . import api as exo_api
 from homeassistant.helpers.device_registry import DeviceRegistry, async_get
 from homeassistant.helpers import entity_registry as er
@@ -89,6 +89,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry, ["sensor", "binary_sensor", "switch", "number", "button", "climate"]
         )
         if result and entry.entry_id in hass.data[DOMAIN]:
+            cleanup_entry(hass, entry)
             del hass.data[DOMAIN][entry.entry_id]
         _LOGGER.debug("Unloaded platforms for entry: %s", entry.entry_id)
         return result

--- a/custom_components/exo_pool/api.py
+++ b/custom_components/exo_pool/api.py
@@ -15,6 +15,52 @@ import asyncio
 
 _LOGGER = logging.getLogger(__name__)
 
+# Header names we want to surface when present on any response
+_RATE_LIMIT_HEADERS = frozenset(
+    h.lower()
+    for h in (
+        "Retry-After",
+        "X-RateLimit-Limit",
+        "X-RateLimit-Remaining",
+        "X-RateLimit-Reset",
+        "RateLimit-Limit",
+        "RateLimit-Remaining",
+        "RateLimit-Reset",
+        "RateLimit-Policy",
+        "X-Rate-Limit-Limit",
+        "X-Rate-Limit-Remaining",
+        "X-Rate-Limit-Reset",
+    )
+)
+
+
+_SENSITIVE_HEADER_NAMES = frozenset(
+    h.lower()
+    for h in (
+        "Authorization",
+        "Set-Cookie",
+        "X-Amz-Security-Token",
+        "X-Amzn-Remapped-Authorization",
+    )
+)
+
+
+def _log_response_headers(
+    response: aiohttp.ClientResponse, *, label: str
+) -> None:
+    """Log all response headers at DEBUG; highlight any rate-limit headers at INFO."""
+    headers_dict = {
+        k: ("REDACTED" if k.lower() in _SENSITIVE_HEADER_NAMES else v)
+        for k, v in response.headers.items()
+    }
+    _LOGGER.debug("%s response headers: %s", label, headers_dict)
+    rate_headers = {
+        k: v for k, v in headers_dict.items() if k.lower() in _RATE_LIMIT_HEADERS
+    }
+    if rate_headers:
+        _LOGGER.info("%s rate-limit headers found: %s", label, rate_headers)
+
+
 # API endpoints and keys from config_flow.py and REST sensors
 LOGIN_URL = "https://prod.zodiac-io.com/users/v1/login"
 REFRESH_URL = "https://prod.zodiac-io.com/users/v1/refresh"
@@ -56,6 +102,12 @@ READ_DEFERRAL_JITTER_MIN = 15.0
 READ_DEFERRAL_JITTER_MAX = 45.0
 DEBOUNCE_JITTER_MIN = 30.0
 DEBOUNCE_JITTER_MAX = 90.0
+
+# AWS IoT MQTT
+IOT_ENDPOINT = "a1zi08qpbrtjyq-ats.iot.us-east-1.amazonaws.com"
+IOT_REGION = "us-east-1"
+MQTT_CREDENTIAL_REFRESH_BUFFER = 300  # refresh 5 min before expiry
+REST_FALLBACK_INTERVAL = 3600  # 1 hour REST poll - last resort when MQTT is dead
 
 
 async def _async_rate_limit(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -328,6 +380,15 @@ async def async_update_data(hass: HomeAssistant, entry: ConfigEntry):
     id_token = entry.data.get("id_token")
     expires_at = entry.data.get("expires_at", 0)
 
+    # Log whether this is the initial fetch or a REST fallback
+    mqtt_client = store.get("mqtt_client")
+    if mqtt_client and mqtt_client.connected:
+        _LOGGER.debug("REST poll fired while MQTT is connected (likely initial fetch)")
+    elif mqtt_client:
+        _LOGGER.warning("REST fallback poll - MQTT is disconnected")
+    else:
+        _LOGGER.debug("REST fetch (MQTT not yet initialized)")
+
     # Reuse Home Assistant's shared aiohttp client session
     session = aiohttp_client.async_get_clientsession(hass)
     # Refresh token if missing, expired, or about to expire
@@ -366,6 +427,7 @@ async def async_update_data(hass: HomeAssistant, entry: ConfigEntry):
         DATA_URL_TEMPLATE.format(serial_number), headers=headers
     ) as response:
         _LOGGER.debug("Data fetch response status: %s", response.status)
+        _log_response_headers(response, label="Data fetch")
         if response.status != 200:
             error_text = await response.text()
             is_rate_limited = response.status == 429 or "Too Many Requests" in str(
@@ -489,6 +551,7 @@ async def _full_login(
     await _async_rate_limit(hass, entry)
     async with session.post(LOGIN_URL, json=payload, headers=headers) as response:
         _LOGGER.debug("Login response status: %s", response.status)
+        _log_response_headers(response, label="Login")
         if response.status != 200:
             error_text = await response.text()
             _LOGGER.error("Failed to authenticate: %s", error_text)
@@ -530,6 +593,7 @@ async def _full_login(
         if refresh_token:
             update_data["refresh_token"] = refresh_token
         hass.config_entries.async_update_entry(entry, data=update_data)
+        _store_aws_credentials(hass, entry, data)
 
 
 async def _refresh_token(
@@ -545,6 +609,7 @@ async def _refresh_token(
     await _async_rate_limit(hass, entry)
     async with session.post(REFRESH_URL, json=payload, headers=headers) as response:
         _LOGGER.debug("Refresh response status: %s", response.status)
+        _log_response_headers(response, label="Token refresh")
         if response.status != 200:
             error_text = await response.text()
             _LOGGER.error("Failed to refresh token: %s", error_text)
@@ -574,6 +639,7 @@ async def _refresh_token(
         if refresh_token:
             update_data["refresh_token"] = refresh_token
         hass.config_entries.async_update_entry(entry, data=update_data)
+        _store_aws_credentials(hass, entry, data)
         return True
 
 
@@ -592,6 +658,20 @@ def _get_entry_store(hass: HomeAssistant, entry: ConfigEntry) -> dict:
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
     return hass.data[DOMAIN].setdefault(entry.entry_id, {})
+
+
+def _store_aws_credentials(hass: HomeAssistant, entry: ConfigEntry, data: dict) -> None:
+    """Extract and store AWS credentials from a login/refresh response."""
+    credentials = data.get("credentials")
+    if not credentials:
+        _LOGGER.debug("No AWS credentials in response - MQTT will use REST fallback")
+        return
+    store = _get_entry_store(hass, entry)
+    store["aws_credentials"] = credentials
+    _LOGGER.debug(
+        "Stored AWS credentials (expire %s)",
+        credentials.get("Expiration", "unknown"),
+    )
 
 
 async def _async_boost_refresh_interval(
@@ -679,20 +759,48 @@ def _apply_schedule_update(
 async def _execute_write(
     hass: HomeAssistant, entry: ConfigEntry, item: _WriteItem
 ) -> None:
+    if item.kind == "pool":
+        desired = {"equipment": {"swc_0": item.payload}}
+    elif item.kind == "heating":
+        desired = {"heating": {item.target: item.payload}}
+    elif item.kind == "schedule":
+        desired = {"schedules": {item.target: item.payload}}
+    else:
+        raise Exception(f"Unknown write kind: {item.kind}")
+
+    # Try MQTT first - no rate limits, instant delivery
+    store = _get_entry_store(hass, entry)
+    mqtt_client = store.get("mqtt_client")
+    if mqtt_client and mqtt_client.connected:
+        _LOGGER.debug("Writing %s via MQTT: %s", item.key, desired)
+        try:
+            mqtt_client.publish_desired(desired)
+            return
+        except Exception:
+            _LOGGER.warning(
+                "MQTT write failed for %s - falling back to REST",
+                item.key,
+                exc_info=True,
+            )
+
+    # REST fallback
+    _LOGGER.debug("Writing %s via REST fallback", item.key)
+    await _execute_write_rest(hass, entry, item, desired)
+
+
+async def _execute_write_rest(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    item: _WriteItem,
+    desired: dict,
+) -> None:
+    """Execute a write via REST POST (fallback when MQTT is unavailable)."""
     serial_number = entry.data["serial_number"]
     id_token = entry.data.get("id_token")
     if not id_token:
         raise Exception(f"No id_token available for write {item.key}")
 
-    if item.kind == "pool":
-        payload = {"state": {"desired": {"equipment": {"swc_0": item.payload}}}}
-    elif item.kind == "heating":
-        payload = {"state": {"desired": {"heating": {item.target: item.payload}}}}
-    elif item.kind == "schedule":
-        payload = {"state": {"desired": {"schedules": {item.target: item.payload}}}}
-    else:
-        raise Exception(f"Unknown write kind: {item.kind}")
-
+    payload = {"state": {"desired": desired}}
     headers = {
         "Content-Type": "application/json; charset=utf-8",
         "User-Agent": "okhttp/3.14.7",
@@ -780,6 +888,7 @@ async def _post_write(
     """Post a write request and return the response status and body."""
     await _async_rate_limit(hass, entry)
     async with session.post(url, json=payload, headers=headers) as response:
+        _log_response_headers(response, label=f"Write ({item_key})")
         response_text = await response.text()
         _LOGGER.debug(
             "Write response for %s: %s %s",
@@ -788,6 +897,167 @@ async def _post_write(
             response_text,
         )
         return response.status, response_text
+
+
+async def _async_refresh_and_reconnect(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    """Refresh AWS credentials and reconnect MQTT.
+
+    Called when MQTT reconnect fails due to expired credentials,
+    or proactively by the credential refresh timer.
+    """
+    try:
+        session = aiohttp_client.async_get_clientsession(hass)
+        await _refresh_authentication(hass, entry, session)
+        await hass.async_add_executor_job(_connect_mqtt, hass, entry)
+    except Exception:
+        _LOGGER.warning("MQTT credential refresh and reconnect failed", exc_info=True)
+
+
+def _connect_mqtt(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Create and connect the MQTT client if AWS credentials are available.
+
+    Runs in a background thread since awsiotsdk connect is blocking.
+    On success, shadow updates feed directly into the coordinator
+    via async_set_updated_data, and the REST poll interval is relaxed
+    to a 30-minute fallback.
+    """
+    store = _get_entry_store(hass, entry)
+    credentials = store.get("aws_credentials")
+    if not credentials:
+        # Credentials aren't stored yet - the token was still valid from the
+        # previous session so _full_login/_refresh_token wasn't called.
+        # Do an explicit token refresh to get AWS credentials.
+        _LOGGER.debug("No AWS credentials yet - triggering token refresh to obtain them")
+        import asyncio
+
+        async def _fetch_credentials():
+            session = aiohttp_client.async_get_clientsession(hass)
+            await _refresh_authentication(hass, entry, session)
+
+        future = asyncio.run_coroutine_threadsafe(_fetch_credentials(), hass.loop)
+        try:
+            future.result(timeout=30)
+        except Exception:
+            _LOGGER.warning("Failed to obtain AWS credentials", exc_info=True)
+            return False
+        credentials = store.get("aws_credentials")
+        if not credentials:
+            _LOGGER.debug("Still no AWS credentials after refresh - skipping MQTT")
+            return False
+
+    coordinator = store.get("coordinator")
+    if coordinator is None:
+        return False
+
+    from .mqtt_client import ExoMqttClient
+
+    mqtt_client = store.get("mqtt_client")
+    if mqtt_client is None:
+        mqtt_client = ExoMqttClient(
+            loop=hass.loop,
+            endpoint=IOT_ENDPOINT,
+            region=IOT_REGION,
+            serial=entry.data["serial_number"],
+        )
+        store["mqtt_client"] = mqtt_client
+
+    def _on_shadow_update(reported: dict) -> None:
+        """Called on HA event loop when MQTT delivers a shadow update."""
+        coordinator.async_set_updated_data(reported)
+
+    mqtt_client.set_shadow_callback(_on_shadow_update)
+
+    def _on_reconnect_failed() -> None:
+        """Called on HA event loop when MQTT re-subscribe fails (stale credentials)."""
+        _LOGGER.warning("MQTT reconnect failed - refreshing credentials")
+        hass.async_create_background_task(
+            _async_refresh_and_reconnect(hass, entry),
+            name="exo_pool_reconnect_refresh",
+        )
+
+    mqtt_client.set_reconnect_failed_callback(_on_reconnect_failed)
+
+    try:
+        mqtt_client.connect(credentials)
+        # Relax REST polling - MQTT push resets the timer on each update
+        coordinator.update_interval = timedelta(seconds=REST_FALLBACK_INTERVAL)
+        _LOGGER.info(
+            "MQTT connected - REST fallback interval set to %ss",
+            REST_FALLBACK_INTERVAL,
+        )
+    except Exception:
+        _LOGGER.warning(
+            "MQTT connection failed - continuing with REST polling",
+            exc_info=True,
+        )
+        # Schedule credential refresh on the HA event loop (not from this worker thread)
+        hass.loop.call_soon_threadsafe(_schedule_credential_refresh, hass, entry)
+        return False
+    # Schedule credential refresh on the HA event loop (not from this worker thread)
+    hass.loop.call_soon_threadsafe(_schedule_credential_refresh, hass, entry)
+    return True
+
+
+def _schedule_credential_refresh(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Schedule MQTT credential refresh before they expire."""
+    store = _get_entry_store(hass, entry)
+    credentials = store.get("aws_credentials")
+    if not credentials:
+        return
+
+    # Cancel any existing refresh task
+    if task := store.get("credential_refresh_task"):
+        task.cancel()
+
+    expiration_str = credentials.get("Expiration", "")
+    if not expiration_str:
+        return
+
+    from datetime import datetime, timezone
+
+    try:
+        expires_at = datetime.fromisoformat(
+            expiration_str.replace("Z", "+00:00")
+        ).timestamp()
+    except (ValueError, TypeError):
+        _LOGGER.warning("Could not parse credential expiration: %s", expiration_str)
+        return
+
+    delay = max(0, expires_at - time.time() - MQTT_CREDENTIAL_REFRESH_BUFFER)
+    _LOGGER.debug("Scheduling MQTT credential refresh in %.0fs", delay)
+
+    async def _proactive_refresh() -> None:
+        await asyncio.sleep(delay)
+        _LOGGER.info("Refreshing AWS credentials for MQTT")
+        await _async_refresh_and_reconnect(hass, entry)
+
+    store["credential_refresh_task"] = hass.async_create_background_task(
+        _proactive_refresh(),
+        name="exo_pool_credential_refresh",
+    )
+
+
+def cleanup_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Clean up MQTT client and scheduled tasks for a config entry.
+
+    Called from async_unload_entry before the store is deleted.
+    """
+    store = _get_entry_store(hass, entry)
+
+    # Disconnect MQTT
+    mqtt_client = store.get("mqtt_client")
+    if mqtt_client:
+        try:
+            mqtt_client.disconnect()
+        except Exception:
+            _LOGGER.debug("Error disconnecting MQTT during cleanup", exc_info=True)
+
+    # Cancel scheduled tasks
+    for task_key in ("credential_refresh_task", "debounce_refresh_task", "boost_task"):
+        if task := store.get(task_key):
+            task.cancel()
 
 
 async def get_coordinator(hass: HomeAssistant, entry: ConfigEntry):
@@ -801,16 +1071,31 @@ async def get_coordinator(hass: HomeAssistant, entry: ConfigEntry):
             _LOGGER,
             name="Exo Pool",
             update_method=lambda: async_update_data(hass, entry),
-            # Poll at a moderate interval to reduce cloud load
             update_interval=timedelta(seconds=seconds),
         )
         store["coordinator"] = coordinator
-        # Perform initial refresh
-        try:
+        # Try MQTT first - avoids REST call and potential 429 on startup
+        mqtt_connected = await hass.async_add_executor_job(
+            _connect_mqtt, hass, entry
+        )
+        if mqtt_connected:
+            # MQTT connected and delivered initial shadow via get/accepted.
+            # Wait briefly for the shadow callback to populate coordinator.data.
+            for _ in range(20):
+                if coordinator.data:
+                    break
+                await asyncio.sleep(0.5)
+            if coordinator.data:
+                _LOGGER.info("Initial data loaded via MQTT - skipping REST fetch")
+            else:
+                _LOGGER.warning(
+                    "MQTT connected but no shadow data received - falling back to REST"
+                )
+                await coordinator.async_config_entry_first_refresh()
+        else:
+            # MQTT failed - fall back to REST for initial data
+            _LOGGER.info("MQTT not available - loading initial data via REST")
             await coordinator.async_config_entry_first_refresh()
-        except Exception as e:
-            _LOGGER.error("Initial data fetch failed: %s", e)
-            raise
     return store["coordinator"]
 
 

--- a/custom_components/exo_pool/manifest.json
+++ b/custom_components/exo_pool/manifest.json
@@ -7,7 +7,8 @@
   "config_flow": true,
   "documentation": "https://github.com/benjycov/exo_pool",
   "integration_type": "hub",
-  "iot_class": "cloud_polling",
+  "iot_class": "cloud_push",
+  "requirements": ["awsiotsdk>=1.28.0"],
   "issue_tracker": "https://github.com/benjycov/exo_pool/issues",
   "version": "0.1.17"
 }

--- a/custom_components/exo_pool/mqtt_client.py
+++ b/custom_components/exo_pool/mqtt_client.py
@@ -1,0 +1,286 @@
+"""AWS IoT MQTT client for eXO device shadow communication.
+
+Wraps the awsiotsdk library to provide a clean interface for connecting
+to AWS IoT, subscribing to device shadow topics, and publishing desired
+state changes. Handles the CRT thread to asyncio event loop bridge.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Callable
+
+from awscrt import auth, io, mqtt
+from awsiot import mqtt_connection_builder
+
+_LOGGER = logging.getLogger(__name__)
+
+# Shadow MQTT topic patterns
+_SHADOW_GET = "$aws/things/{serial}/shadow/get"
+_SHADOW_GET_ACCEPTED = "$aws/things/{serial}/shadow/get/accepted"
+_SHADOW_UPDATE = "$aws/things/{serial}/shadow/update"
+_SHADOW_UPDATE_DOCUMENTS = "$aws/things/{serial}/shadow/update/documents"
+_SHADOW_UPDATE_ACCEPTED = "$aws/things/{serial}/shadow/update/accepted"
+_SHADOW_UPDATE_DELTA = "$aws/things/{serial}/shadow/update/delta"
+
+_SUBSCRIBE_TOPICS = (
+    _SHADOW_GET_ACCEPTED,
+    _SHADOW_UPDATE_DOCUMENTS,
+    _SHADOW_UPDATE_ACCEPTED,
+    _SHADOW_UPDATE_DELTA,
+)
+
+_SUBSCRIBE_TIMEOUT = 5
+_CONNECT_TIMEOUT = 10
+_DISCONNECT_TIMEOUT = 5
+_SUBSCRIBE_DELAY = 0.3
+_HEARTBEAT_INTERVAL = 900  # 15 min shadow refresh via MQTT
+
+
+class ExoMqttClient:
+    """AWS IoT MQTT client for eXO device shadow.
+
+    Manages a persistent MQTT connection to AWS IoT for real-time
+    shadow updates. All shadow callbacks are bridged onto the provided
+    event loop (typically the HA event loop) via call_soon_threadsafe.
+    """
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        endpoint: str,
+        region: str,
+        serial: str,
+    ) -> None:
+        self._loop = loop
+        self._endpoint = endpoint
+        self._region = region
+        self._serial = serial
+        self._connection: mqtt.Connection | None = None
+        self._connected = False
+        self._shadow_callback: Callable[[dict], None] | None = None
+        self._reconnect_failed_callback: Callable[[], None] | None = None
+        self._heartbeat_cancel: Callable | None = None
+
+        # CRT resources - created once, reused across reconnections
+        self._event_loop_group = io.EventLoopGroup(1)
+        self._host_resolver = io.DefaultHostResolver(self._event_loop_group)
+        self._client_bootstrap = io.ClientBootstrap(
+            self._event_loop_group, self._host_resolver
+        )
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    def set_shadow_callback(self, callback: Callable[[dict], None]) -> None:
+        """Register a callback for shadow state updates.
+
+        The callback receives the reported state dict and is always
+        invoked on the event loop passed to the constructor.
+        """
+        self._shadow_callback = callback
+
+    def set_reconnect_failed_callback(self, callback: Callable[[], None]) -> None:
+        """Register a callback invoked when re-subscribe fails after reconnect.
+
+        This typically means credentials have expired. The callback is
+        invoked on the HA event loop and should refresh credentials and
+        call connect() again.
+        """
+        self._reconnect_failed_callback = callback
+
+    def connect(self, credentials: dict) -> None:
+        """Connect to AWS IoT and subscribe to shadow topics.
+
+        If already connected, disconnects first (for credential refresh).
+        This is a blocking call (waits for connection + subscriptions).
+        """
+        if self._connection is not None:
+            self.disconnect()
+
+        self._connection = self._build_connection(credentials)
+        self._connection.connect().result(timeout=_CONNECT_TIMEOUT)
+        self._connected = True
+        _LOGGER.info("MQTT connected to %s for device %s", self._endpoint, self._serial)
+
+        self._subscribe_shadow_topics()
+        self._request_shadow()
+        self._start_heartbeat()
+
+    def disconnect(self) -> None:
+        """Disconnect from AWS IoT."""
+        self._stop_heartbeat()
+        if self._connection is not None:
+            try:
+                self._connection.disconnect().result(timeout=_DISCONNECT_TIMEOUT)
+            except Exception:
+                _LOGGER.debug("MQTT disconnect error (ignored)", exc_info=True)
+            self._connection = None
+        self._connected = False
+
+    def publish_desired(self, desired: dict) -> None:
+        """Publish a desired state change to the device shadow.
+
+        Raises ConnectionError if not connected.
+        """
+        if not self._connected or self._connection is None:
+            raise ConnectionError("MQTT not connected")
+
+        topic = _SHADOW_UPDATE.format(serial=self._serial)
+        payload = json.dumps({"state": {"desired": desired}})
+        self._connection.publish(
+            topic=topic,
+            payload=payload,
+            qos=mqtt.QoS.AT_LEAST_ONCE,
+        )
+        _LOGGER.info("MQTT write: %s", desired)
+
+    def _build_connection(self, credentials: dict) -> mqtt.Connection:
+        """Build an MQTT connection with SigV4 WebSocket auth."""
+        credentials_provider = auth.AwsCredentialsProvider.new_static(
+            access_key_id=credentials["AccessKeyId"],
+            secret_access_key=credentials["SecretKey"],
+            session_token=credentials["SessionToken"],
+        )
+
+        return mqtt_connection_builder.websockets_with_default_aws_signing(
+            endpoint=self._endpoint,
+            region=self._region,
+            credentials_provider=credentials_provider,
+            client_bootstrap=self._client_bootstrap,
+            client_id=f"exo_pool_{self._serial}_{int(time.time())}",
+            clean_session=True,
+            keep_alive_secs=30,
+            on_connection_interrupted=self._on_connection_interrupted,
+            on_connection_resumed=self._on_connection_resumed,
+        )
+
+    def _subscribe_shadow_topics(self) -> bool:
+        """Subscribe to all shadow topics with the appropriate callbacks.
+
+        Returns True if at least one topic was subscribed successfully.
+        """
+        success_count = 0
+        for topic_template in _SUBSCRIBE_TOPICS:
+            topic = topic_template.format(serial=self._serial)
+            try:
+                future, _ = self._connection.subscribe(
+                    topic=topic,
+                    qos=mqtt.QoS.AT_LEAST_ONCE,
+                    callback=self._on_shadow_message,
+                )
+                future.result(timeout=_SUBSCRIBE_TIMEOUT)
+                _LOGGER.debug("Subscribed to %s", topic)
+                success_count += 1
+            except Exception:
+                _LOGGER.warning("Failed to subscribe to %s", topic, exc_info=True)
+            time.sleep(_SUBSCRIBE_DELAY)
+        return success_count > 0
+
+    def _request_shadow(self) -> None:
+        """Publish to shadow/get to request the current shadow state."""
+        topic = _SHADOW_GET.format(serial=self._serial)
+        self._connection.publish(
+            topic=topic,
+            payload="{}",
+            qos=mqtt.QoS.AT_LEAST_ONCE,
+        )
+        _LOGGER.debug("Requested shadow state via %s", topic)
+
+    def _start_heartbeat(self) -> None:
+        """Start periodic shadow/get to keep coordinator data fresh."""
+        self._stop_heartbeat()
+        handle = self._loop.call_later(
+            _HEARTBEAT_INTERVAL, self._heartbeat_tick
+        )
+        self._heartbeat_cancel = handle.cancel
+
+    def _stop_heartbeat(self) -> None:
+        """Cancel the heartbeat timer."""
+        if self._heartbeat_cancel is not None:
+            self._heartbeat_cancel()
+            self._heartbeat_cancel = None
+
+    def _heartbeat_tick(self) -> None:
+        """Fire a shadow/get and reschedule."""
+        if self._connected and self._connection is not None:
+            _LOGGER.debug("MQTT heartbeat - requesting shadow state")
+            self._request_shadow()
+        self._start_heartbeat()
+
+    def _on_shadow_message(self, topic, payload, dup, qos, retain, **kwargs):
+        """Handle incoming shadow messages (runs on CRT thread)."""
+        try:
+            data = json.loads(payload)
+        except (json.JSONDecodeError, TypeError):
+            _LOGGER.warning("Malformed shadow payload on %s", topic)
+            return
+
+        reported = self._extract_reported(topic, data)
+        if reported is None:
+            _LOGGER.debug("Shadow message on %s (no reported state to extract)", topic)
+            return
+
+        _LOGGER.info("Shadow update received via %s", topic.split("/")[-1])
+        if "update/documents" in topic:
+            previous = data.get("previous", {}).get("state", {}).get("reported")
+            if previous:
+                changes = _summarize_changes(previous, reported)
+                if changes:
+                    _LOGGER.info("Shadow changes: %s", ", ".join(changes))
+
+        if self._shadow_callback is not None:
+            self._loop.call_soon_threadsafe(self._shadow_callback, reported)
+
+    def _extract_reported(self, topic: str, data: dict) -> dict | None:
+        """Extract the reported state dict from a shadow message."""
+        if "update/documents" in topic:
+            return data.get("current", {}).get("state", {}).get("reported")
+        if "get/accepted" in topic:
+            return data.get("state", {}).get("reported")
+        # update/accepted and update/delta don't carry the full reported state
+        return None
+
+    def _on_connection_interrupted(self, connection, error, **kwargs):
+        """Called by CRT when the connection drops."""
+        self._connected = False
+        _LOGGER.warning("MQTT connection interrupted: %s", error)
+
+    def _on_connection_resumed(self, connection, return_code, session_present, **kwargs):
+        """Called by CRT when the connection is re-established."""
+        _LOGGER.info(
+            "MQTT connection resumed (rc=%s, session_present=%s)",
+            return_code,
+            session_present,
+        )
+        self._connected = True
+        # Re-subscribe since we use clean_session=True
+        if self._subscribe_shadow_topics():
+            self._request_shadow()
+        else:
+            _LOGGER.warning(
+                "All subscribes failed after reconnect - credentials may have expired"
+            )
+            self._connected = False
+            if self._reconnect_failed_callback is not None:
+                self._loop.call_soon_threadsafe(self._reconnect_failed_callback)
+
+
+def _summarize_changes(old: dict, new: dict, path: str = "") -> list[str]:
+    """Return a list of human-readable change descriptions."""
+    changes = []
+    all_keys = set(list(old.keys()) + list(new.keys()))
+    for key in sorted(all_keys):
+        full_path = f"{path}.{key}" if path else key
+        old_val = old.get(key)
+        new_val = new.get(key)
+        if old_val == new_val:
+            continue
+        if isinstance(old_val, dict) and isinstance(new_val, dict):
+            changes.extend(_summarize_changes(old_val, new_val, full_path))
+        else:
+            changes.append(f"{full_path}: {old_val} -> {new_val}")
+    return changes

--- a/custom_components/exo_pool/number.py
+++ b/custom_components/exo_pool/number.py
@@ -77,7 +77,7 @@ class ExoPoolORPSetPointNumber(CoordinatorEntity, NumberEntity):
 
     _attr_icon = "mdi:water-check"
     _attr_mode = "box"
-    _attr_step = 10
+    _attr_native_step = 10
     _attr_native_min_value = 600
     _attr_native_max_value = 900
 
@@ -119,7 +119,7 @@ class ExoPoolPHSetPointNumber(CoordinatorEntity, NumberEntity):
 
     _attr_icon = "mdi:test-tube"
     _attr_mode = "box"
-    _attr_step = 0.1
+    _attr_native_step = 0.1
     _attr_native_min_value = 6.0
     _attr_native_max_value = 7.6
 
@@ -162,7 +162,7 @@ class ExoPoolSwcOutputNumber(CoordinatorEntity, NumberEntity):
 
     _attr_icon = "mdi:water-percent"
     _attr_mode = "box"
-    _attr_step = 1
+    _attr_native_step = 1
     _attr_native_min_value = 0
     _attr_native_max_value = 100
     _attr_native_unit_of_measurement = PERCENTAGE
@@ -198,7 +198,7 @@ class ExoPoolSwcLowOutputNumber(CoordinatorEntity, NumberEntity):
 
     _attr_icon = "mdi:water-percent"
     _attr_mode = "box"
-    _attr_step = 1
+    _attr_native_step = 1
     _attr_native_min_value = 0
     _attr_native_max_value = 100
     _attr_native_unit_of_measurement = PERCENTAGE
@@ -236,7 +236,7 @@ class ExoPoolRefreshIntervalNumber(CoordinatorEntity, NumberEntity):
 
     _attr_icon = "mdi:update"
     _attr_mode = "box"
-    _attr_step = 1
+    _attr_native_step = 1
     _attr_native_min_value = REFRESH_MIN
     _attr_native_max_value = REFRESH_MAX
     _attr_native_unit_of_measurement = UnitOfTime.SECONDS

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,16 @@
+services:
+  homeassistant:
+    container_name: ha-exo-pool-dev
+    image: ghcr.io/home-assistant/home-assistant:stable
+    volumes:
+      # Mount the custom component directly - edits reflect on restart
+      - ./custom_components/exo_pool:/config/custom_components/exo_pool:ro
+      # Persist HA config/state across restarts
+      - ha-exo-pool-dev-config:/config
+    ports:
+      - "8125:8123"
+    stop_grace_period: 30s
+    restart: unless-stopped
+
+volumes:
+  ha-exo-pool-dev-config:

--- a/scripts/dev-setup.py
+++ b/scripts/dev-setup.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+Automated Home Assistant dev instance setup for exo_pool.
+
+Usage:
+    python3 scripts/dev-setup.py
+
+Creates the HA account, completes onboarding, adds the exo_pool
+integration using credentials from .env, and configures debug logging.
+Saves the auth token to .dev-token for future use.
+
+Requires EXO_EMAIL and EXO_PASSWORD in .env (or environment).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+HA_URL = "http://localhost:8125"
+TOKEN_FILE = ".dev-token"
+ENV_FILE = ".env"
+DEV_PASSWORD = "devdevdev"  # NOSONAR - intentional dev-only credential, not a real secret
+DEV_USER = {"name": "Developer", "username": "dev", "password": DEV_PASSWORD, "language": "en"}
+HOME_LOCATION = {
+    "latitude": -33.701,
+    "longitude": 151.209,
+    "country": "AU",
+    "time_zone": "Australia/Sydney",
+    "elevation": 200,
+    "unit_system": "metric",
+    "currency": "AUD",
+    "language": "en",
+}
+LOGGER_CONFIG = {
+    "default": "warning",
+    "logs": {"custom_components.exo_pool": "debug"},
+}
+
+
+def _load_env() -> dict:
+    """Load key=value pairs from .env file."""
+    env = {}
+    try:
+        with open(ENV_FILE) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" in line:
+                    k, v = line.split("=", 1)
+                    env[k.strip()] = v.strip()
+    except FileNotFoundError:
+        pass
+    return env
+
+
+def _request(method: str, path: str, data: dict | None = None,
+             token: str | None = None, form: bool = False) -> dict | None:
+    url = f"{HA_URL}{path}"
+    headers = {}
+    body = None
+
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    if data is not None:
+        if form:
+            body = urllib.parse.urlencode(data).encode()
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+        else:
+            body = json.dumps(data).encode()
+            headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        print(f"  HTTP {e.code} on {method} {path}: {raw[:200]}")
+        return None
+
+
+def wait_for_ha(timeout: int = 120) -> None:
+    print("Waiting for HA to start...", end="", flush=True)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(f"{HA_URL}/api/")
+            urllib.request.urlopen(req, timeout=2)
+            print(" ready")
+            return
+        except urllib.error.HTTPError as e:
+            if e.code in (401, 403):
+                print(" ready")
+                return
+            print(".", end="", flush=True)
+            time.sleep(2)
+        except OSError:
+            print(".", end="", flush=True)
+            time.sleep(2)
+    print("\nTimed out waiting for HA")
+    sys.exit(1)
+
+
+def _login(token_file: str = TOKEN_FILE) -> str:
+    """Log in with existing credentials and return a fresh auth token."""
+    print("Logging in with existing credentials...")
+    flow = _request("POST", "/auth/login_flow", {
+        "client_id": f"{HA_URL}/",
+        "handler": ["homeassistant", None],
+        "redirect_uri": f"{HA_URL}/",
+    })
+    if not flow or "flow_id" not in flow:
+        print("Failed to start login flow")
+        sys.exit(1)
+
+    result = _request("POST", f"/auth/login_flow/{flow['flow_id']}", {
+        "username": DEV_USER["username"],
+        "password": DEV_USER["password"],
+        "client_id": f"{HA_URL}/",
+    })
+    if not result or result.get("type") != "create_entry":
+        print(f"Login failed: {result}")
+        sys.exit(1)
+
+    auth_code = result["result"]
+    token_resp = _request("POST", "/auth/token", {
+        "client_id": f"{HA_URL}/",
+        "grant_type": "authorization_code",
+        "code": auth_code,
+    }, form=True)
+    if not token_resp or "access_token" not in token_resp:
+        print("Failed to get token")
+        sys.exit(1)
+
+    token = token_resp["access_token"]
+    with open(token_file, "w") as f:
+        f.write(token)
+    print(f"Token saved to {token_file}")
+    return token
+
+
+def onboard(token_file: str = TOKEN_FILE) -> str:
+    """Create account, get token, complete onboarding. Returns auth token."""
+    try:
+        with open(token_file) as f:
+            token = f.read().strip()
+        resp = _request("GET", "/api/", token=token)
+        if resp is not None:
+            print("Using saved token")
+            return token
+    except FileNotFoundError:
+        pass
+
+    result = _request("GET", "/api/onboarding")
+    if not result:
+        return _login(token_file)
+
+    remaining = [step["step"] for step in result if not step.get("done", False)]
+    if "user" not in remaining:
+        return _login(token_file)
+
+    print("Creating dev account...")
+    payload = {**DEV_USER, "client_id": f"{HA_URL}/"}
+    resp = _request("POST", "/api/onboarding/users", payload)
+    if not resp or "auth_code" not in resp:
+        print("Failed to create user")
+        sys.exit(1)
+
+    auth_code = resp["auth_code"]
+
+    print("Getting auth token...")
+    token_resp = _request("POST", "/auth/token", {
+        "client_id": f"{HA_URL}/",
+        "grant_type": "authorization_code",
+        "code": auth_code,
+    }, form=True)
+    if not token_resp or "access_token" not in token_resp:
+        print("Failed to get token")
+        sys.exit(1)
+
+    token = token_resp["access_token"]
+
+    print("Completing onboarding...")
+    _request("POST", "/api/onboarding/core_config", HOME_LOCATION, token=token)
+    _request("POST", "/api/onboarding/analytics", {}, token=token)
+
+    with open(token_file, "w") as f:
+        f.write(token)
+    print(f"Token saved to {token_file}")
+    return token
+
+
+def configure_logging(token: str) -> None:
+    """Set up debug logging for exo_pool via the HA API."""
+    print("Configuring debug logging for exo_pool...")
+    _request("POST", "/api/services/logger/set_level",
+             {"custom_components.exo_pool": "debug"}, token=token)
+
+
+def _extract_system_options(schema: list) -> list:
+    """Extract system options from a config flow data_schema."""
+    for field in schema:
+        if field.get("name") == "system":
+            opts = field.get("options", {})
+            return list(opts.keys()) if isinstance(opts, dict) else list(opts)
+        if "options" in field:
+            opts = field["options"]
+            return list(opts.keys()) if isinstance(opts, dict) else list(opts)
+    return []
+
+
+def add_integration(token: str, email: str, password: str) -> bool:
+    """Add the exo_pool integration via config flow."""
+    entries = _request("GET", "/api/config/config_entries/entry", token=token)
+    if entries:
+        for entry in entries:
+            if entry.get("domain") == "exo_pool":
+                print("Integration already configured")
+                return True
+
+    print("Adding exo_pool integration...")
+
+    flow = _request("POST", "/api/config/config_entries/flow",
+                     {"handler": "exo_pool"}, token=token)
+    if not flow or "flow_id" not in flow:
+        print("Failed to init config flow")
+        return False
+
+    flow_id = flow["flow_id"]
+
+    print("  Submitting credentials...")
+    result = _request("POST", f"/api/config/config_entries/flow/{flow_id}",
+                       {"email": email, "password": password}, token=token)
+    if not result:
+        print("  Failed to submit credentials")
+        return False
+
+    if result.get("type") == "create_entry":
+        print(f"  Integration added: {result.get('title', 'exo_pool')}")
+        return True
+
+    if result.get("type") != "form" or result.get("step_id") != "select_system":
+        print(f"  Unexpected flow result: {json.dumps(result)[:500]}")
+        return False
+
+    options = _extract_system_options(result.get("data_schema", []))
+    if not options:
+        print(f"  No systems found in flow response: {json.dumps(result)[:500]}")
+        return False
+
+    system = options[0]
+    print(f"  Selecting system: {system}")
+    result = _request("POST", f"/api/config/config_entries/flow/{flow_id}",
+                       {"system": system}, token=token)
+    if result and result.get("type") == "create_entry":
+        print(f"  Integration added: {result.get('title', 'exo_pool')}")
+        return True
+
+    print(f"  Unexpected flow result: {json.dumps(result)[:500]}")
+    return False
+
+
+def start_docker() -> None:
+    """Start the HA dev container."""
+    result = subprocess.run(["docker", "ps", "-q", "-f", "name=ha-exo-pool-dev"],
+                            capture_output=True, text=True)
+    if result.stdout.strip():
+        print("HA container already running")
+        return
+
+    print("Starting HA container...")
+    subprocess.run(
+        ["docker", "compose", "-f", "docker-compose.dev.yml", "up", "-d"],
+        capture_output=True,
+    )
+
+
+def main() -> None:
+    env = _load_env()
+    email = os.environ.get("EXO_EMAIL") or env.get("EXO_EMAIL")
+    password = os.environ.get("EXO_PASSWORD") or env.get("EXO_PASSWORD")
+
+    if not email or not password:
+        print("Set EXO_EMAIL and EXO_PASSWORD in .env or environment")
+        sys.exit(1)
+
+    start_docker()
+    wait_for_ha()
+    token = onboard()
+    configure_logging(token)
+    add_integration(token, email, password)
+
+    print(f"\nHA dev instance ready at {HA_URL}")
+    print(f"Login: {DEV_USER['username']} / {DEV_USER['password']}")
+    print("\nUseful commands:")
+    print("  make logs       # watch logs")
+    print("  make restart    # restart after code changes")
+    print("  make stop       # stop container")
+    print("  make test       # run tests")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,96 @@
+"""Shared fixtures for exo_pool tests."""
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+import types
+
+import pytest
+
+# Stub out the homeassistant package so mqtt_client.py can be imported
+# without a full HA installation. mqtt_client.py itself has no HA deps,
+# but importing via custom_components.exo_pool triggers __init__.py which does.
+# We pre-register the mqtt_client module directly to short-circuit that.
+_REPO_ROOT = pathlib.Path(__file__).parent.parent
+_mqtt_spec = importlib.util.spec_from_file_location(
+    "custom_components.exo_pool.mqtt_client",
+    _REPO_ROOT / "custom_components" / "exo_pool" / "mqtt_client.py",
+)
+_mqtt_mod = importlib.util.module_from_spec(_mqtt_spec)
+
+# Ensure parent packages exist in sys.modules
+for pkg in ("custom_components", "custom_components.exo_pool"):
+    if pkg not in sys.modules:
+        sys.modules[pkg] = types.ModuleType(pkg)
+
+sys.modules["custom_components.exo_pool.mqtt_client"] = _mqtt_mod
+_mqtt_spec.loader.exec_module(_mqtt_mod)
+
+
+SAMPLE_CREDENTIALS = {
+    "AccessKeyId": "AKIAIOSFODNN7EXAMPLE",
+    "SecretKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    "SessionToken": "FwoGZXIvYXdzEBYaDH7example+session+token",
+    "Expiration": "2026-04-15T10:00:00.000Z",
+    "IdentityId": "us-east-1:00000000-0000-0000-0000-000000000000",
+}
+
+SAMPLE_SERIAL = "JT00000000"
+IOT_ENDPOINT = "a1zi08qpbrtjyq-ats.iot.us-east-1.amazonaws.com"
+IOT_REGION = "us-east-1"
+
+
+@pytest.fixture
+def mock_mqtt_connection():
+    """Create a mock MQTT connection that behaves like awscrt mqtt."""
+    from unittest.mock import MagicMock
+
+    conn = MagicMock()
+
+    connect_future = MagicMock()
+    connect_future.result.return_value = None
+    conn.connect.return_value = connect_future
+
+    disconnect_future = MagicMock()
+    disconnect_future.result.return_value = None
+    conn.disconnect.return_value = disconnect_future
+
+    sub_future = MagicMock()
+    sub_future.result.return_value = None
+    conn.subscribe.return_value = (sub_future, 1)
+
+    pub_future = MagicMock()
+    pub_future.result.return_value = None
+    conn.publish.return_value = (pub_future, 1)
+
+    return conn
+
+
+@pytest.fixture
+def mock_event_loop():
+    """Mock the HA event loop for thread-safe callback bridging."""
+    from unittest.mock import MagicMock
+
+    loop = MagicMock()
+    loop.call_soon_threadsafe = MagicMock()
+    return loop
+
+
+@pytest.fixture
+def build_client(mock_mqtt_connection, mock_event_loop):
+    """Factory to build an ExoMqttClient with mocked internals."""
+    from unittest.mock import MagicMock
+    from custom_components.exo_pool.mqtt_client import ExoMqttClient
+
+    def _build(**kwargs):
+        client = ExoMqttClient(
+            loop=mock_event_loop,
+            endpoint=kwargs.get("endpoint", IOT_ENDPOINT),
+            region=kwargs.get("region", IOT_REGION),
+            serial=kwargs.get("serial", SAMPLE_SERIAL),
+        )
+        client._build_connection = MagicMock(return_value=mock_mqtt_connection)
+        return client
+
+    return _build

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -1,0 +1,555 @@
+"""Tests for ExoMqttClient - AWS IoT MQTT client for eXO device shadow."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.conftest import (
+    IOT_ENDPOINT,
+    IOT_REGION,
+    SAMPLE_CREDENTIALS,
+    SAMPLE_SERIAL,
+)
+
+# Fixtures mock_mqtt_connection, mock_event_loop, and build_client
+# are defined in conftest.py and shared with test_mqtt_integration.py.
+
+
+class TestConnect:
+    """Connection lifecycle tests."""
+
+    def test_connect_creates_connection_and_subscribes(
+        self, build_client, mock_mqtt_connection
+    ):
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+
+        # Should have built a connection with the credentials
+        client._build_connection.assert_called_once_with(SAMPLE_CREDENTIALS)
+
+        # Should have connected
+        mock_mqtt_connection.connect.assert_called_once()
+
+        # Should have subscribed to shadow topics
+        subscribed_topics = [
+            c.kwargs["topic"] if "topic" in c.kwargs else c.args[0]
+            for c in mock_mqtt_connection.subscribe.call_args_list
+        ]
+        assert f"$aws/things/{SAMPLE_SERIAL}/shadow/get/accepted" in subscribed_topics
+        assert (
+            f"$aws/things/{SAMPLE_SERIAL}/shadow/update/documents"
+            in subscribed_topics
+        )
+        assert (
+            f"$aws/things/{SAMPLE_SERIAL}/shadow/update/accepted"
+            in subscribed_topics
+        )
+        assert (
+            f"$aws/things/{SAMPLE_SERIAL}/shadow/update/delta" in subscribed_topics
+        )
+
+    def test_connect_requests_initial_shadow(
+        self, build_client, mock_mqtt_connection
+    ):
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+
+        # Should publish to shadow/get to request current state
+        publish_calls = mock_mqtt_connection.publish.call_args_list
+        get_calls = [
+            c
+            for c in publish_calls
+            if f"$aws/things/{SAMPLE_SERIAL}/shadow/get"
+            == (c.kwargs.get("topic") or c.args[0])
+        ]
+        assert len(get_calls) == 1
+
+    def test_connected_property_reflects_state(
+        self, build_client, mock_mqtt_connection
+    ):
+        client = build_client()
+        assert client.connected is False
+
+        client.connect(SAMPLE_CREDENTIALS)
+        assert client.connected is True
+
+    def test_connect_when_already_connected_disconnects_first(
+        self, build_client, mock_mqtt_connection
+    ):
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+        assert mock_mqtt_connection.disconnect.call_count == 0
+
+        # Connect again (e.g. credential refresh)
+        client.connect(SAMPLE_CREDENTIALS)
+        # Should have disconnected the old connection first
+        assert mock_mqtt_connection.disconnect.call_count == 1
+
+
+class TestDisconnect:
+    """Disconnect tests."""
+
+    def test_disconnect_when_connected(self, build_client, mock_mqtt_connection):
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+        client.disconnect()
+
+        mock_mqtt_connection.disconnect.assert_called_once()
+        assert client.connected is False
+
+    def test_disconnect_when_not_connected(self, build_client):
+        client = build_client()
+        # Should not raise
+        client.disconnect()
+        assert client.connected is False
+
+
+class TestShadowCallback:
+    """Shadow update callback tests."""
+
+    def test_shadow_callback_invoked_on_update_documents(
+        self, build_client, mock_mqtt_connection, mock_event_loop
+    ):
+        callback = MagicMock()
+        client = build_client()
+        client.set_shadow_callback(callback)
+        client.connect(SAMPLE_CREDENTIALS)
+
+        # Find the callback registered for update/documents
+        doc_sub_call = None
+        for c in mock_mqtt_connection.subscribe.call_args_list:
+            topic = c.kwargs.get("topic") or c.args[0]
+            if "update/documents" in topic:
+                doc_sub_call = c
+                break
+        assert doc_sub_call is not None, "No subscription for update/documents"
+
+        # Extract the callback the client registered with subscribe()
+        mqtt_callback = doc_sub_call.kwargs.get("callback") or doc_sub_call.args[2]
+
+        # Simulate a shadow update message
+        reported_state = {
+            "equipment": {"swc_0": {"swc": 40, "production": 1}},
+            "schedules": {},
+        }
+        shadow_doc = {
+            "current": {
+                "state": {"reported": reported_state, "desired": {}},
+            },
+            "previous": {
+                "state": {"reported": {"equipment": {"swc_0": {"swc": 30}}}}
+            },
+            "timestamp": 1776208189,
+        }
+        mqtt_callback(
+            topic=f"$aws/things/{SAMPLE_SERIAL}/shadow/update/documents",
+            payload=json.dumps(shadow_doc).encode(),
+            dup=False,
+            qos=1,
+            retain=False,
+        )
+
+        # Should bridge to HA event loop, not call directly
+        mock_event_loop.call_soon_threadsafe.assert_called()
+        # Extract the callback and args passed to call_soon_threadsafe
+        bridged_call = mock_event_loop.call_soon_threadsafe.call_args
+        bridged_fn = bridged_call.args[0]
+        bridged_args = bridged_call.args[1:]
+
+        # Execute the bridged callback
+        bridged_fn(*bridged_args)
+
+        # Now our shadow callback should have received the reported state
+        callback.assert_called_once_with(reported_state)
+
+    def test_shadow_callback_invoked_on_get_accepted(
+        self, build_client, mock_mqtt_connection, mock_event_loop
+    ):
+        callback = MagicMock()
+        client = build_client()
+        client.set_shadow_callback(callback)
+        client.connect(SAMPLE_CREDENTIALS)
+
+        # Find the get/accepted subscription callback
+        get_sub_call = None
+        for c in mock_mqtt_connection.subscribe.call_args_list:
+            topic = c.kwargs.get("topic") or c.args[0]
+            if "get/accepted" in topic:
+                get_sub_call = c
+                break
+        assert get_sub_call is not None
+
+        mqtt_callback = get_sub_call.kwargs.get("callback") or get_sub_call.args[2]
+
+        reported_state = {"equipment": {"swc_0": {"swc": 30}}}
+        shadow_get = {
+            "state": {"reported": reported_state},
+            "metadata": {},
+            "version": 150334,
+            "timestamp": 1776206206,
+        }
+        mqtt_callback(
+            topic=f"$aws/things/{SAMPLE_SERIAL}/shadow/get/accepted",
+            payload=json.dumps(shadow_get).encode(),
+            dup=False,
+            qos=1,
+            retain=False,
+        )
+
+        mock_event_loop.call_soon_threadsafe.assert_called()
+        bridged_fn = mock_event_loop.call_soon_threadsafe.call_args.args[0]
+        bridged_args = mock_event_loop.call_soon_threadsafe.call_args.args[1:]
+        bridged_fn(*bridged_args)
+
+        callback.assert_called_once_with(reported_state)
+
+    def test_no_callback_set_does_not_bridge(
+        self, build_client, mock_mqtt_connection, mock_event_loop
+    ):
+        client = build_client()
+        # No callback set
+        client.connect(SAMPLE_CREDENTIALS)
+        mock_event_loop.call_soon_threadsafe.reset_mock()
+
+        # Fire a shadow update - should not attempt to bridge to event loop
+        for c in mock_mqtt_connection.subscribe.call_args_list:
+            topic = c.kwargs.get("topic") or c.args[0]
+            if "update/documents" in topic:
+                mqtt_callback = c.kwargs.get("callback") or c.args[2]
+                shadow_doc = {
+                    "current": {"state": {"reported": {}}},
+                    "previous": {"state": {"reported": {}}},
+                    "timestamp": 0,
+                }
+                mqtt_callback(
+                    topic=topic,
+                    payload=json.dumps(shadow_doc).encode(),
+                    dup=False,
+                    qos=1,
+                    retain=False,
+                )
+                break
+
+        mock_event_loop.call_soon_threadsafe.assert_not_called()
+
+    def test_malformed_payload_does_not_raise(
+        self, build_client, mock_mqtt_connection
+    ):
+        callback = MagicMock()
+        client = build_client()
+        client.set_shadow_callback(callback)
+        client.connect(SAMPLE_CREDENTIALS)
+
+        for c in mock_mqtt_connection.subscribe.call_args_list:
+            topic = c.kwargs.get("topic") or c.args[0]
+            if "update/documents" in topic:
+                mqtt_callback = c.kwargs.get("callback") or c.args[2]
+                # Send garbage
+                mqtt_callback(
+                    topic=topic,
+                    payload=b"not json{{{",
+                    dup=False,
+                    qos=1,
+                    retain=False,
+                )
+                break
+
+        # Callback should NOT have been called with bad data
+        callback.assert_not_called()
+
+    def test_update_accepted_does_not_invoke_callback(
+        self, build_client, mock_mqtt_connection, mock_event_loop
+    ):
+        """update/accepted carries partial state - should not feed coordinator."""
+        callback = MagicMock()
+        client = build_client()
+        client.set_shadow_callback(callback)
+        client.connect(SAMPLE_CREDENTIALS)
+        mock_event_loop.call_soon_threadsafe.reset_mock()
+
+        for c in mock_mqtt_connection.subscribe.call_args_list:
+            topic = c.kwargs.get("topic") or c.args[0]
+            if "update/accepted" in topic:
+                mqtt_callback = c.kwargs.get("callback") or c.args[2]
+                mqtt_callback(
+                    topic=topic,
+                    payload=json.dumps({
+                        "state": {"desired": {"equipment": {"swc_0": {"swc": 40}}}},
+                        "metadata": {},
+                        "version": 150335,
+                        "timestamp": 1776208189,
+                    }).encode(),
+                    dup=False, qos=1, retain=False,
+                )
+                break
+
+        mock_event_loop.call_soon_threadsafe.assert_not_called()
+
+    def test_update_delta_does_not_invoke_callback(
+        self, build_client, mock_mqtt_connection, mock_event_loop
+    ):
+        """update/delta carries only changed fields - should not feed coordinator."""
+        callback = MagicMock()
+        client = build_client()
+        client.set_shadow_callback(callback)
+        client.connect(SAMPLE_CREDENTIALS)
+        mock_event_loop.call_soon_threadsafe.reset_mock()
+
+        for c in mock_mqtt_connection.subscribe.call_args_list:
+            topic = c.kwargs.get("topic") or c.args[0]
+            if "update/delta" in topic:
+                mqtt_callback = c.kwargs.get("callback") or c.args[2]
+                mqtt_callback(
+                    topic=topic,
+                    payload=json.dumps({
+                        "state": {"equipment": {"swc_0": {"swc": 40}}},
+                        "version": 150335,
+                        "timestamp": 1776208189,
+                    }).encode(),
+                    dup=False, qos=1, retain=False,
+                )
+                break
+
+        mock_event_loop.call_soon_threadsafe.assert_not_called()
+
+
+class TestPublishDesired:
+    """Write (desired state) tests."""
+
+    def test_publish_desired_sends_to_shadow_update(
+        self, build_client, mock_mqtt_connection
+    ):
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+
+        desired = {"equipment": {"swc_0": {"swc": 40}}}
+        client.publish_desired(desired)
+
+        # Find the publish call for shadow/update
+        update_calls = [
+            c
+            for c in mock_mqtt_connection.publish.call_args_list
+            if f"$aws/things/{SAMPLE_SERIAL}/shadow/update"
+            == (c.kwargs.get("topic") or c.args[0])
+        ]
+        assert len(update_calls) == 1
+
+        payload = json.loads(
+            update_calls[0].kwargs.get("payload") or update_calls[0].args[1]
+        )
+        assert payload == {"state": {"desired": desired}}
+
+    def test_publish_desired_raises_when_not_connected(self, build_client):
+        client = build_client()
+
+        with pytest.raises(ConnectionError):
+            client.publish_desired({"equipment": {"swc_0": {"swc": 40}}})
+
+
+class TestReconnection:
+    """Reconnection and connection event tests."""
+
+    def test_on_connection_interrupted_sets_connected_false(
+        self, build_client, mock_mqtt_connection
+    ):
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+        assert client.connected is True
+
+        # Simulate connection interrupted
+        client._on_connection_interrupted(
+            connection=mock_mqtt_connection, error=Exception("network down")
+        )
+        assert client.connected is False
+
+    def test_on_connection_resumed_resubscribes_and_gets_shadow(
+        self, build_client, mock_mqtt_connection
+    ):
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+        initial_sub_count = mock_mqtt_connection.subscribe.call_count
+        initial_pub_count = mock_mqtt_connection.publish.call_count
+
+        # Simulate reconnection
+        client._on_connection_resumed(
+            connection=mock_mqtt_connection,
+            return_code=0,
+            session_present=False,
+        )
+
+        # Should re-subscribe to topics
+        assert mock_mqtt_connection.subscribe.call_count > initial_sub_count
+
+        # Should re-request shadow
+        new_pub_calls = mock_mqtt_connection.publish.call_args_list[
+            initial_pub_count:
+        ]
+        get_calls = [
+            c
+            for c in new_pub_calls
+            if (c.kwargs.get("topic") or c.args[0]).endswith("/shadow/get")
+        ]
+        assert len(get_calls) == 1
+
+    def test_on_connection_resumed_restores_connected_state(
+        self, build_client, mock_mqtt_connection
+    ):
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+        client._on_connection_interrupted(
+            connection=mock_mqtt_connection, error=Exception("blip")
+        )
+        assert client.connected is False
+
+        client._on_connection_resumed(
+            connection=mock_mqtt_connection,
+            return_code=0,
+            session_present=False,
+        )
+        assert client.connected is True
+
+    def test_on_connection_resumed_calls_reconnect_failed_on_subscribe_error(
+        self, build_client, mock_mqtt_connection, mock_event_loop
+    ):
+        reconnect_cb = MagicMock()
+        client = build_client()
+        client.set_reconnect_failed_callback(reconnect_cb)
+        client.connect(SAMPLE_CREDENTIALS)
+
+        # Make subscribe fail on reconnect (simulating expired credentials)
+        sub_future = MagicMock()
+        sub_future.result.side_effect = Exception("Forbidden")
+        mock_mqtt_connection.subscribe.return_value = (sub_future, 1)
+
+        client._on_connection_interrupted(
+            connection=mock_mqtt_connection, error=Exception("blip")
+        )
+        client._on_connection_resumed(
+            connection=mock_mqtt_connection,
+            return_code=0,
+            session_present=False,
+        )
+
+        assert client.connected is False
+        mock_event_loop.call_soon_threadsafe.assert_called_with(reconnect_cb)
+
+
+class TestHeartbeat:
+    """Heartbeat (periodic shadow/get) tests."""
+
+    def test_connect_starts_heartbeat(self, build_client, mock_event_loop):
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+
+        # Should have scheduled a call_later on the event loop
+        mock_event_loop.call_later.assert_called()
+        args = mock_event_loop.call_later.call_args
+        interval = args.args[0] if args.args else args[0][0]
+        from custom_components.exo_pool.mqtt_client import _HEARTBEAT_INTERVAL
+
+        assert interval == _HEARTBEAT_INTERVAL
+
+    def test_heartbeat_tick_requests_shadow(
+        self, build_client, mock_mqtt_connection
+    ):
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+        initial_pub_count = mock_mqtt_connection.publish.call_count
+
+        # Simulate the heartbeat firing
+        client._heartbeat_tick()
+
+        new_pub_calls = mock_mqtt_connection.publish.call_args_list[
+            initial_pub_count:
+        ]
+        get_calls = [
+            c
+            for c in new_pub_calls
+            if (c.kwargs.get("topic") or c.args[0]).endswith("/shadow/get")
+        ]
+        assert len(get_calls) == 1
+
+    def test_heartbeat_reschedules_after_tick(
+        self, build_client, mock_event_loop
+    ):
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+        initial_call_count = mock_event_loop.call_later.call_count
+
+        client._heartbeat_tick()
+
+        assert mock_event_loop.call_later.call_count > initial_call_count
+
+    def test_heartbeat_skips_when_disconnected(
+        self, build_client, mock_mqtt_connection
+    ):
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+        initial_pub_count = mock_mqtt_connection.publish.call_count
+
+        client._on_connection_interrupted(
+            connection=mock_mqtt_connection, error=Exception("down")
+        )
+
+        client._heartbeat_tick()
+
+        # Should not publish when disconnected
+        new_pub_calls = mock_mqtt_connection.publish.call_args_list[
+            initial_pub_count:
+        ]
+        get_calls = [
+            c
+            for c in new_pub_calls
+            if (c.kwargs.get("topic") or c.args[0]).endswith("/shadow/get")
+        ]
+        assert len(get_calls) == 0
+
+    def test_disconnect_cancels_heartbeat(self, build_client, mock_event_loop):
+        # Set up call_later to return a mock handle with cancel()
+        mock_handle = MagicMock()
+        mock_event_loop.call_later.return_value = mock_handle
+
+        client = build_client()
+        client.connect(SAMPLE_CREDENTIALS)
+        client.disconnect()
+
+        mock_handle.cancel.assert_called()
+
+
+class TestBuildConnection:
+    """Test that _build_connection creates a properly configured MQTT connection."""
+
+    def test_build_connection_uses_sigv4_websockets(self):
+        from unittest.mock import patch
+        from custom_components.exo_pool.mqtt_client import ExoMqttClient
+        import custom_components.exo_pool.mqtt_client as mqtt_mod
+
+        mock_conn = MagicMock()
+
+        with patch.object(
+            mqtt_mod,
+            "mqtt_connection_builder",
+        ) as mock_builder:
+            mock_builder.websockets_with_default_aws_signing.return_value = mock_conn
+
+            loop = MagicMock()
+            client = ExoMqttClient(
+                loop=loop,
+                endpoint=IOT_ENDPOINT,
+                region=IOT_REGION,
+                serial=SAMPLE_SERIAL,
+            )
+            result = client._build_connection(SAMPLE_CREDENTIALS)
+
+        mock_builder.websockets_with_default_aws_signing.assert_called_once()
+        call_kwargs = mock_builder.websockets_with_default_aws_signing.call_args.kwargs
+
+        assert call_kwargs["endpoint"] == IOT_ENDPOINT
+        assert call_kwargs["region"] == IOT_REGION
+        assert "credentials_provider" in call_kwargs
+        assert call_kwargs["on_connection_interrupted"] == client._on_connection_interrupted
+        assert call_kwargs["on_connection_resumed"] == client._on_connection_resumed
+
+        assert result is mock_conn

--- a/tests/test_mqtt_integration.py
+++ b/tests/test_mqtt_integration.py
@@ -1,0 +1,400 @@
+"""Integration test: MQTT shadow messages → coordinator data contract.
+
+Verifies that shadow payloads from AWS IoT produce data in the exact
+shape that the existing entity platforms expect. Uses real device data
+captured from a real eXO device as test fixtures.
+
+This is the critical integration seam - if these tests pass, the entities
+will render correctly regardless of whether data came from REST or MQTT.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.conftest import SAMPLE_CREDENTIALS, SAMPLE_SERIAL
+
+
+# ---------------------------------------------------------------------------
+# Real device shadow data captured from an eXO device
+# ---------------------------------------------------------------------------
+
+REAL_REPORTED_STATE = {
+    "aws": {
+        "status": "connected",
+        "timestamp": 1776201508702,
+        "session_id": "3c42fd81-6249-4d80-851d-3b5634fbe5bf",
+    },
+    "debug": {
+        "Version Firmware": "V85W4B0",
+        "RSSI": -43,
+        "MQTT connection": 1,
+        "Last error": 65278,
+    },
+    "vr": "V85W4",
+    "equipment": {
+        "swc_0": {
+            "orp_sp": 700,
+            "ph_sp": 74,
+            "swc": 30,
+            "swc_low": 20,
+            "sns_1": {"sensor_type": "Ph", "state": 1, "value": 73},
+            "sns_2": {"sensor_type": "Orp", "state": 0, "value": 0},
+            "sns_3": {"sensor_type": "Water temp", "state": 1, "value": 22},
+            "temp": 1,
+            "vsp": 1,
+            "boost": 0,
+            "boost_time": "24:00",
+            "aux_1": {"state": 0, "type": "none", "color": 0, "mode": 0},
+            "aux_2": {"state": 0, "color": 0, "mode": 0, "type": "none"},
+            "vr": "V85R70",
+            "production": 1,
+            "filter_pump": {"state": 1, "type": 1},
+            "low": 0,
+            "ph_only": 1,
+            "dual_link": 0,
+            "error_code": 0,
+            "error_state": 0,
+            "lang": 0,
+            "amp": 1,
+            "aux230": 0,
+            "sn": "ALWA00000000000000",
+            "version": "V1",
+            "exo_state": 1,
+        },
+    },
+    "schedules": {
+        "sch1": {
+            "timer": {"start": "00:00", "end": "00:00"},
+            "enabled": 0,
+            "active": 0,
+            "id": "sch_1",
+            "name": "Salt Water Chlorinator 1",
+            "endpoint": "swc_1",
+        },
+        "sch3": {
+            "enabled": 0,
+            "active": 0,
+            "id": "sch_3",
+            "name": "Filter Pump 1",
+            "endpoint": "ssp_1",
+            "timer": {"start": "00:00", "end": "00:00"},
+        },
+        "supported": 5,
+        "programmed": 0,
+    },
+}
+
+
+def _make_get_accepted(reported: dict) -> bytes:
+    """Build a shadow/get/accepted payload."""
+    return json.dumps({
+        "state": {"reported": reported},
+        "metadata": {},
+        "version": 150334,
+        "timestamp": 1776206206,
+    }).encode()
+
+
+def _make_update_documents(current_reported: dict, previous_reported: dict) -> bytes:
+    """Build a shadow/update/documents payload."""
+    return json.dumps({
+        "current": {"state": {"reported": current_reported, "desired": {}}},
+        "previous": {"state": {"reported": previous_reported, "desired": {}}},
+        "timestamp": 1776208189,
+    }).encode()
+
+
+@pytest.fixture
+def connected_client(build_client, mock_mqtt_connection, mock_event_loop):
+    """An ExoMqttClient connected with mocked MQTT internals.
+
+    Uses shared fixtures from conftest. The event loop bridge executes
+    callbacks synchronously so received_data is populated immediately.
+    """
+    received_data = []
+
+    def capture_call_soon(fn, *args):
+        fn(*args)
+
+    mock_event_loop.call_soon_threadsafe = capture_call_soon
+
+    client = build_client()
+    client.set_shadow_callback(lambda data: received_data.append(data))
+    client.connect(SAMPLE_CREDENTIALS)
+
+    return client, mock_mqtt_connection, received_data
+
+
+@pytest.fixture
+def get_accepted_data(connected_client):
+    """Fire a get/accepted message and return the parsed coordinator data."""
+    _, mock_conn, received = connected_client
+    cb = _get_subscribe_callback(mock_conn, "get/accepted")
+    cb(
+        topic=f"$aws/things/{SAMPLE_SERIAL}/shadow/get/accepted",
+        payload=_make_get_accepted(REAL_REPORTED_STATE),
+        dup=False, qos=1, retain=False,
+    )
+    return received[0]
+
+
+def _get_subscribe_callback(mock_conn, topic_fragment: str):
+    """Find the MQTT callback registered for a topic containing the fragment."""
+    for c in mock_conn.subscribe.call_args_list:
+        topic = c.kwargs.get("topic") or c.args[0]
+        if topic_fragment in topic:
+            return c.kwargs.get("callback") or c.args[2]
+    raise AssertionError(f"No subscription found matching '{topic_fragment}'")
+
+
+class TestGetAcceptedDataContract:
+    """shadow/get/accepted → coordinator data matches entity expectations."""
+
+    def test_full_reported_state_reaches_callback(self, get_accepted_data):
+        assert get_accepted_data == REAL_REPORTED_STATE
+
+    def test_sensor_data_paths_exist(self, get_accepted_data):
+        """All sensor.py read paths must be present in coordinator data."""
+        swc = get_accepted_data["equipment"]["swc_0"]
+
+        # TempSensor
+        assert swc["sns_3"]["value"] == 22
+
+        # ORPSensor
+        assert swc["sns_2"]["value"] == 0
+        assert swc["orp_sp"] == 700
+
+        # PHSensor (value is ×10 in raw, entity divides)
+        assert swc["sns_1"]["value"] == 73
+        assert swc["ph_sp"] == 74
+
+        # SWCOutputSensor
+        assert swc["swc"] == 30
+
+        # SWCLowOutputSensor
+        assert swc["swc_low"] == 20
+
+        # ErrorCodeSensor
+        assert swc["error_code"] == 0
+
+        # WifiRssiSensor
+        assert get_accepted_data["debug"]["RSSI"] == -43
+
+    def test_binary_sensor_data_paths_exist(self, get_accepted_data):
+        """All binary_sensor.py read paths must be present."""
+        swc = get_accepted_data["equipment"]["swc_0"]
+
+        # FilterPumpBinarySensor
+        assert swc["filter_pump"]["state"] == 1
+
+        # ErrorStateBinarySensor
+        assert swc["error_state"] == 0
+
+        # SaltWaterChlorinatorBinarySensor
+        assert swc["production"] == 1
+
+        # AwsConnectivityBinarySensor
+        assert get_accepted_data["aws"]["status"] == "connected"
+
+        # ScheduleBinarySensor - schedules dict exists with valid entries
+        schedules = get_accepted_data["schedules"]
+        assert "sch1" in schedules
+        assert schedules["sch1"]["active"] == 0
+
+    def test_switch_data_paths_exist(self, get_accepted_data):
+        """All switch.py read paths must be present."""
+        swc = get_accepted_data["equipment"]["swc_0"]
+
+        # ORPBoostSwitch
+        assert swc["boost"] == 0
+        assert swc["boost_time"] == "24:00"
+
+        # PowerSwitch
+        assert swc["exo_state"] == 1
+
+        # ChlorinatorSwitch
+        assert swc["production"] == 1
+
+        # Aux1Switch
+        assert swc["aux_1"]["state"] == 0
+
+        # Aux2Switch
+        assert swc["aux_2"]["state"] == 0
+
+        # SWCLowModeSwitch
+        assert swc["low"] == 0
+
+    def test_number_data_paths_exist(self, get_accepted_data):
+        """All number.py read paths must be present."""
+        swc = get_accepted_data["equipment"]["swc_0"]
+
+        # Capability flags that control which number entities are created
+        assert swc["ph_only"] == 1
+        assert swc["dual_link"] == 0
+
+        # ExoPoolSwcOutputNumber
+        assert swc["swc"] == REAL_REPORTED_STATE["equipment"]["swc_0"]["swc"]
+
+        # ExoPoolSwcLowOutputNumber
+        assert swc["swc_low"] == REAL_REPORTED_STATE["equipment"]["swc_0"]["swc_low"]
+
+    def test_climate_data_paths_exist(self, get_accepted_data):
+        """climate.py reads from equipment.swc_0 and aux_2."""
+        swc = get_accepted_data["equipment"]["swc_0"]
+
+        # Climate reads water temp for current_temperature
+        assert swc["sns_3"]["value"] == 22
+
+        # Climate reads aux_2.mode to decide visibility
+        assert swc["aux_2"]["mode"] == 0  # not heat mode, so climate won't show
+
+
+class TestUpdateDocumentsDataContract:
+    """shadow/update/documents → coordinator data on state change."""
+
+    def test_chlorinator_percentage_change(self, connected_client):
+        """Simulates the exact change we observed: swc 30 → 40."""
+        _, mock_conn, received = connected_client
+        cb = _get_subscribe_callback(mock_conn, "update/documents")
+
+        current = json.loads(json.dumps(REAL_REPORTED_STATE))
+        previous = json.loads(json.dumps(REAL_REPORTED_STATE))
+        current["equipment"]["swc_0"]["swc"] = 40  # changed
+        previous["equipment"]["swc_0"]["swc"] = 30  # original
+
+        cb(
+            topic=f"$aws/things/{SAMPLE_SERIAL}/shadow/update/documents",
+            payload=_make_update_documents(current, previous),
+            dup=False, qos=1, retain=False,
+        )
+
+        assert len(received) == 1
+        data = received[0]
+        assert data["equipment"]["swc_0"]["swc"] == 40
+
+    def test_aux_switch_toggle(self, connected_client):
+        """Simulates aux_1 toggled on."""
+        _, mock_conn, received = connected_client
+        cb = _get_subscribe_callback(mock_conn, "update/documents")
+
+        current = json.loads(json.dumps(REAL_REPORTED_STATE))
+        previous = json.loads(json.dumps(REAL_REPORTED_STATE))
+        current["equipment"]["swc_0"]["aux_1"]["state"] = 1
+
+        cb(
+            topic=f"$aws/things/{SAMPLE_SERIAL}/shadow/update/documents",
+            payload=_make_update_documents(current, previous),
+            dup=False, qos=1, retain=False,
+        )
+
+        assert received[0]["equipment"]["swc_0"]["aux_1"]["state"] == 1
+
+    def test_ph_sensor_reading_update(self, connected_client):
+        """Simulates a device-pushed sensor reading (no user action)."""
+        _, mock_conn, received = connected_client
+        cb = _get_subscribe_callback(mock_conn, "update/documents")
+
+        current = json.loads(json.dumps(REAL_REPORTED_STATE))
+        previous = json.loads(json.dumps(REAL_REPORTED_STATE))
+        current["equipment"]["swc_0"]["sns_1"]["value"] = 74  # pH changed
+
+        cb(
+            topic=f"$aws/things/{SAMPLE_SERIAL}/shadow/update/documents",
+            payload=_make_update_documents(current, previous),
+            dup=False, qos=1, retain=False,
+        )
+
+        assert received[0]["equipment"]["swc_0"]["sns_1"]["value"] == 74
+
+    def test_schedule_activation(self, connected_client):
+        """Simulates a schedule becoming active."""
+        _, mock_conn, received = connected_client
+        cb = _get_subscribe_callback(mock_conn, "update/documents")
+
+        current = json.loads(json.dumps(REAL_REPORTED_STATE))
+        previous = json.loads(json.dumps(REAL_REPORTED_STATE))
+        current["schedules"]["sch3"]["active"] = 1
+        current["schedules"]["sch3"]["enabled"] = 1
+
+        cb(
+            topic=f"$aws/things/{SAMPLE_SERIAL}/shadow/update/documents",
+            payload=_make_update_documents(current, previous),
+            dup=False, qos=1, retain=False,
+        )
+
+        assert received[0]["schedules"]["sch3"]["active"] == 1
+        assert received[0]["schedules"]["sch3"]["enabled"] == 1
+
+
+class TestPublishDesiredContract:
+    """Verify write payloads match what the device shadow expects."""
+
+    def test_pool_value_write_shape(self, connected_client):
+        """set_pool_value("swc", 40) should produce the right shadow payload."""
+        client, mock_conn, _ = connected_client
+
+        client.publish_desired({"equipment": {"swc_0": {"swc": 40}}})
+
+        pub_calls = [
+            c for c in mock_conn.publish.call_args_list
+            if (c.kwargs.get("topic") or c.args[0]).endswith("/shadow/update")
+        ]
+        assert len(pub_calls) == 1
+
+        payload = json.loads(pub_calls[0].kwargs.get("payload") or pub_calls[0].args[1])
+        assert payload == {
+            "state": {
+                "desired": {
+                    "equipment": {"swc_0": {"swc": 40}},
+                },
+            },
+        }
+
+    def test_heating_write_shape(self, connected_client):
+        """set_heating_value("sp", 28) should produce the right payload."""
+        client, mock_conn, _ = connected_client
+
+        client.publish_desired({"heating": {"sp": 28}})
+
+        pub_calls = [
+            c for c in mock_conn.publish.call_args_list
+            if (c.kwargs.get("topic") or c.args[0]).endswith("/shadow/update")
+        ]
+        assert len(pub_calls) == 1
+
+        payload = json.loads(pub_calls[0].kwargs.get("payload") or pub_calls[0].args[1])
+        assert payload == {
+            "state": {
+                "desired": {
+                    "heating": {"sp": 28},
+                },
+            },
+        }
+
+    def test_schedule_write_shape(self, connected_client):
+        """update_schedule should produce the right payload."""
+        client, mock_conn, _ = connected_client
+
+        client.publish_desired({
+            "schedules": {"sch3": {"timer": {"start": "08:00", "end": "18:00"}}},
+        })
+
+        pub_calls = [
+            c for c in mock_conn.publish.call_args_list
+            if (c.kwargs.get("topic") or c.args[0]).endswith("/shadow/update")
+        ]
+        assert len(pub_calls) == 1
+
+        payload = json.loads(pub_calls[0].kwargs.get("payload") or pub_calls[0].args[1])
+        assert payload == {
+            "state": {
+                "desired": {
+                    "schedules": {
+                        "sch3": {"timer": {"start": "08:00", "end": "18:00"}},
+                    },
+                },
+            },
+        }


### PR DESCRIPTION
## Summary

This PR replaces REST polling with MQTT push as the primary data channel, using the same AWS IoT Device Shadow protocol that the official iAqualink iOS app uses. The result is sub-second state sync, zero 429 rate limit errors, and instant writes.

**No breaking changes.** No additional setup required - the integration uses AWS credentials already returned by the Zodiac login API (previously discarded). Existing config entries work unchanged. REST polling is kept as a 1-hour fallback.

### What changed

- **New `mqtt_client.py`**: wraps `awsiotsdk` to connect to AWS IoT via MQTT over WebSocket with SigV4 auth. Handles subscribe, publish, reconnect, heartbeat (15-min shadow/get), and reconnect failure recovery.
- **`api.py`**: login/refresh now extracts AWS credentials from the response. Coordinator fed by MQTT push via `async_set_updated_data()`. Writes route through MQTT when connected, REST as fallback. Credential refresh scheduled before expiry. Proper cleanup on unload.
- **`manifest.json`**: added `awsiotsdk` dependency, `iot_class` changed to `cloud_push`.
- **`number.py`**: fixed `_attr_step` -> `_attr_native_step` (fixes pH set point validation error in HA frontend).
- **`__init__.py`**: calls `cleanup_entry` on unload (MQTT disconnect, task cancellation).
- **Dev tooling**: `docker-compose.dev.yml`, `Makefile`, `scripts/dev-setup.py` for contributor onboarding.
- **37 tests**: unit tests for MQTT client + integration tests verifying shadow data contract against real device data.

### How it works

1. Login via REST (existing flow) - extract AWS credentials from response
2. Connect MQTT to AWS IoT endpoint
3. Subscribe to shadow topics (`update/documents`, `get/accepted`, etc.)
4. Shadow push events -> `coordinator.async_set_updated_data()` -> entities update instantly
5. Writes publish to `shadow/update` via MQTT (REST fallback if disconnected)
6. 15-minute heartbeat keeps data fresh during quiet periods
7. Credential refresh ~55 min before expiry, with reconnect failure recovery

### Testing

- 37 pytest tests (unit + integration), all passing
- Tested on real hardware: Exo phIQ with pH, chlorinator, aux switches, schedules
- 48+ hours production soak: zero 429s, clean credential refresh cycling, real-time sensor updates
- Multiple rapid HA restarts: clean MQTT reconnect every time

## Test plan

- [x] 37 pytest tests pass
- [x] Sub-second state sync between iAqualink app and HA dashboard
- [x] Writes from HA go via MQTT (pH setpoint, aux switches, chlorinator %)
- [x] Zero 429 rate limit errors over 48+ hour soak
- [x] Credential refresh cycles cleanly every ~55 min
- [x] HA restart reconnects MQTT without 429s
- [x] REST fallback works when MQTT is unavailable
- [x] pH set point validation error fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code) with guardrail rules for strict TDD and clean code. 